### PR TITLE
Reserve the low numbered SIDs for segment routing

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -36,6 +36,19 @@ func NewAtomixStore(ctx context.Context, atomixClient atomix.Client) (SIDStore, 
 		log.Warnf("Error creating atomix counter: %v", err)
 		return nil, err
 	}
+	startingValue, err := nextSID.Get(ctx)
+	if err != nil {
+		log.Warnf("Error querying atomix counter: %v", err)
+		return nil, err
+	}
+	if startingValue < 100 {
+		// Reserve the first 100 SIDs for segment routing
+		err = nextSID.Set(ctx, 100)
+		if err != nil {
+			log.Warnf("Error initializing atomix counter: %v", err)
+			return nil, err
+		}
+	}
 	sidMap, err := atomixClient.GetMap(ctx, SidMap)
 	if err != nil {
 		log.Warnf("Error creating atomix map: %v", err)

--- a/pkg/synchronizer/device_test.go
+++ b/pkg/synchronizer/device_test.go
@@ -248,7 +248,7 @@ func TestDeviceToSegmentRouting(t *testing.T) {
 	assert.NotNil(t, netconfDevice)
 
 	// Check the segment routing data
-	checkSegmentRoutingDevice(t, netconfDevice, 1, deviceTestLeafManagementIP, true)
+	checkSegmentRoutingDevice(t, netconfDevice, 101, deviceTestLeafManagementIP, true)
 
 	port, ok := scope.NetConfig.Ports["device:leaf-one/202"]
 	assert.True(t, ok)
@@ -299,8 +299,8 @@ func TestSIDDUniqueness(t *testing.T) {
 	assert.NotNil(t, leafNetconfDevice)
 
 	// Check the segment routing data
-	checkSegmentRoutingDevice(t, leafNetconfDevice, 1, deviceTestLeafManagementIP, true)
-	checkSegmentRoutingDevice(t, spineNetconfDevice, 2, deviceTestSpineManagementIP, false)
+	checkSegmentRoutingDevice(t, leafNetconfDevice, 101, deviceTestLeafManagementIP, true)
+	checkSegmentRoutingDevice(t, spineNetconfDevice, 102, deviceTestSpineManagementIP, false)
 
 	// check the basic data
 	checkBasic(t, leafNetconfDevice, deviceTestLeafDisplayName)


### PR DESCRIPTION
This PR changes the SID generation to start at 100 rather than 0. Segment routing reserves the low SID numbers for its internal use.