### PR TITLE
Fixes for Stratum hardware switches

### DIFF
--- a/pkg/synchronizer/gnmiclient.go
+++ b/pkg/synchronizer/gnmiclient.go
@@ -50,9 +50,8 @@ func getClientCredentials(useSecure bool) (*tls.Config, error) {
 			Certificates:       []tls.Certificate{cert},
 			InsecureSkipVerify: true,
 		}, nil
-	} else {
-		return nil, nil
 	}
+	return nil, nil
 }
 
 func (c *client) getDestination(useSecure bool) (baseClient.Destination, error) {

--- a/pkg/synchronizer/gnmiclient.go
+++ b/pkg/synchronizer/gnmiclient.go
@@ -113,7 +113,7 @@ func (c *client) Capabilities(ctx context.Context, req *gpb.CapabilityRequest) (
 // Get calls gnmi Get RPC
 func (c *client) Get(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
 	getResponse, err := c.client.Get(ctx, req)
-	_ = c.client.Close()
+	defer c.client.Close()
 	return getResponse, errors.FromGRPC(err)
 }
 
@@ -122,10 +122,10 @@ func (c *client) Set(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse
 	log.Warn("client.Set()")
 
 	c.client = c.getGNMIClient(ctx)
-	log.Warnf("Sending set request %v", req)
+	defer c.client.Close()
+	log.Infof("Sending set request %v", req)
 	setResponse, err := c.client.Set(ctx, req)
-	_ = c.client.Close()
-	log.Warnf("gnmi set operation finished, result is %v", setResponse)
+	log.Infof("gnmi set operation finished, result is %v", setResponse)
 	return setResponse, errors.FromGRPC(err)
 }
 

--- a/pkg/synchronizer/gnmipusher.go
+++ b/pkg/synchronizer/gnmipusher.go
@@ -65,14 +65,16 @@ func NewGNMIPusherWithClient(url string, target string, payload string, path str
 func (p *GNMIPusher) PushUpdate() error {
 	setGnmiRequest := &gnmiapi.SetRequest{}
 
-	// update:{path:{elem:{name:"someURL"} target:"stratum"} val:{string_val:"somepayload"}}
-	//e := &gnmiapi.PathElem{
-	//	Name: p.path,
-	//}
-	//es := []*gnmiapi.PathElem{e}
+	var es []*gnmiapi.PathElem
+	if p.path != "" {
+		e := &gnmiapi.PathElem{
+			Name: p.path,
+		}
+		es = []*gnmiapi.PathElem{e}
+	}
 	path := &gnmiapi.Path{
 		Origin: "",
-		//Elem:   es,
+		Elem:   es,
 		Target: p.target,
 	}
 	tv := &gnmiapi.TypedValue{
@@ -86,16 +88,8 @@ func (p *GNMIPusher) PushUpdate() error {
 		Duplicates: 0,
 	}
 	uds := []*gnmiapi.Update{ud}
-	//var protoBuilder strings.Builder
-	//protoBuilder.WriteString("update:{path:{elem:{name:\"" + p.endpoint + "\"}")
-	//protoBuilder.WriteString("  target:\"" + p.target + "\"}")
-	//protoBuilder.WriteString("val:{string_val:\"" + p.payload + "\"}}")
-	//protoString := protoBuilder.String()
 
 	setGnmiRequest.Replace = uds
-	//if err := proto.UnmarshalText(protoString, setGnmiRequest); err != nil {
-	//	return err
-	//}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/synchronizer/gnmipusher_test.go
+++ b/pkg/synchronizer/gnmipusher_test.go
@@ -44,7 +44,7 @@ func TestGNMIPush(t *testing.T) {
 	tc := &testClient{expectedStatus: http.StatusOK}
 	pusher := NewGNMIPusherWithClient("someURL", "stratum", "somepayload", "path", tc)
 	assert.NoError(t, pusher.PushUpdate())
-	assert.Contains(t, tc.payload, "val:{string_val:\"somepayload\"")
+	assert.Contains(t, tc.payload, "val:{bytes_val:\"somepayload\"")
 }
 
 // TestGNMIPusherError tests that a POST operation that the pusher properly handles an HTTP error on the POST operation

--- a/pkg/synchronizer/synchronize-device.go
+++ b/pkg/synchronizer/synchronize-device.go
@@ -184,7 +184,7 @@ func (s *Synchronizer) handleSwitch(ctx context.Context, scope *FabricScope) err
 		return errors.New("switch pipeconf attribute must be specified")
 	}
 	device.Basic.PipeConf = *pipeconf.Value
-	device.Basic.ManagementAddress = fmt.Sprintf("grpc://%s:%d?device_id=1", *sw.Management.Address, *sw.Management.PortNumber)
+	device.Basic.ManagementAddress = getStratumEndpointForNetcfg(*sw.Management.Address, *sw.Management.PortNumber)
 	// omit for now: locType, gridX, gridY
 
 	// segmentRouting
@@ -400,9 +400,9 @@ nextSwitch:
 		log.Warnf("proto string for switch %s is:\n%s\n", *scope.Switch.SwitchId, protoString)
 
 		// Push proto
-		stratumURI := fmt.Sprintf("%s:%d", *scope.Switch.Management.Address, *scope.Switch.Management.PortNumber)
+		stratumURI := getStratumEndpoint(*scope.Switch.Management.Address, *scope.Switch.Management.PortNumber)
 		log.Warnf("stratum URI %s", stratumURI)
-		gnmiPusher := NewGNMIPusher(stratumURI, "stratum", protoString, "/", scope.SecureTransport)
+		gnmiPusher := NewGNMIPusher(stratumURI, "", protoString, "", scope.SecureTransport)
 		err = gnmiPusher.PushUpdate()
 
 		if err != nil {

--- a/pkg/synchronizer/util.go
+++ b/pkg/synchronizer/util.go
@@ -140,3 +140,13 @@ func managementAddressToIP(address string) string {
 	nextIP++
 	return retval
 }
+
+func getStratumEndpoint(addr string, port uint16) string {
+	endpoint := fmt.Sprintf("%s:%d", addr, port)
+	return endpoint
+}
+
+func getStratumEndpointForNetcfg(addr string, port uint16) string {
+	endpoint := fmt.Sprintf("grpc://%s:%d?device_id=1", addr, port)
+	return endpoint
+}


### PR DESCRIPTION
This PR contains fixes required to get the adapter to push a config down to stratum:

- Stratum only supports the `REPLACE` GNMI request
- Must use plain text GNMI
- Path must be empty
- Payload must be `bytes_val`
- Stratum endpoint is `addr:port`
- Close client side after GNMI request is sent


